### PR TITLE
Refactored script to include current project as default one

### DIFF
--- a/sandbox-cleaner.sh
+++ b/sandbox-cleaner.sh
@@ -1,10 +1,13 @@
+DEFAULT_VALUE=$(oc project --short=true)
+
 if [ $# -eq 0 ]; then
+    echo "This script will execute against your current project"$DEFAULT_VALUE
+else
     echo "The app prefix must be supplied as a command-line parameter, e.g. ./sandbox-cleaner.sh myproject"
-    exit 1
 fi
 
 
-project_prefix=($1-oc get project)
+project_prefix=$(1:-$DEFAULT_VALUE)
 
 oc delete $(oc get pods -o name | grep "$project_prefix")
 oc delete $(oc get secrets -o name | grep "$project_prefix")

--- a/sandbox-cleaner.sh
+++ b/sandbox-cleaner.sh
@@ -3,7 +3,8 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-project_prefix=$1
+
+project_prefix=($1-oc get project)
 
 oc delete $(oc get pods -o name | grep "$project_prefix")
 oc delete $(oc get secrets -o name | grep "$project_prefix")


### PR DESCRIPTION
Refactored the script as following:
- If no project is provided, the current project is used
- It can be used in the browser terminal of the sandbox by running `curl https://raw.githubusercontent.com/DonSchenck/sandbox-cleaner/master/sandbox-cleaner.sh -o sandbox-cleaner.sh && sh sandbox-cleaner`
